### PR TITLE
Don’t mix Promises and throwing Errors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## UNRELEASED
 
 ### Fixed
-* Typeo in the CLI help
+* Always return Promises from start() and stop(), even in case of errors.
+* Typo in the CLI help
 
 ## 0.2.0 2017-10-31
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,25 +8,31 @@ const localHostTc = require('./localHostTc');
 function verify(options) {
   if (options.localhost) {
     if (!Number.isInteger(options.rtt)) {
-      throw Error('You need to set rtt as an integer for localhost');
+      throw new Error('You need to set rtt as an integer for localhost');
     }
   } else if (
     !Number.isInteger(options.up) ||
     !Number.isInteger(options.down) ||
     !Number.isInteger(options.rtt)
   ) {
-    throw Error('Input values needs to be integers');
+    throw new Error('Input values needs to be integers');
   }
 }
 
 module.exports = {
   start(options) {
-    verify(options);
+    try {
+      verify(options);
+    } catch (e) {
+      return Promise.reject(e);
+    }
 
     if (os.platform() === 'darwin') {
       if (options.localhost) {
-        throw Error(
-          'Localhost on ' + os.platform() + ' not supported at the moment'
+        return Promise.reject(
+          new Error(
+            'Localhost on ' + os.platform() + ' not supported at the moment'
+          )
         );
       } else {
         return pfctl.start(options.up, options.down, options.rtt);
@@ -38,7 +44,9 @@ module.exports = {
         return tc.start(options.up, options.down, options.rtt);
       }
     } else {
-      throw Error('Platform ' + os.platform() + ' not supported');
+      return Promise.reject(
+        new Error('Platform ' + os.platform() + ' not supported')
+      );
     }
   },
   stop(options) {
@@ -51,7 +59,9 @@ module.exports = {
         return tc.stop();
       }
     } else {
-      throw Error('Platform ' + os.platform() + ' not supported');
+      return Promise.reject(
+        new Error('Platform ' + os.platform() + ' not supported')
+      );
     }
   }
 };


### PR DESCRIPTION
Previously start() and stop() would return Promises in most cases, but some error conditions resulted in an Error being thrown. Update so all error cases returns a rejected Promise.