### PR TITLE
Starting throttling with tc had a race condition.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## UNRELEASED
 
 ### Fixed
+* Ensure setup has completed fully before returning when starting throttling with tc.
 * Always return Promises from start() and stop(), even in case of errors.
 * Typo in the CLI help
 

--- a/lib/tc.js
+++ b/lib/tc.js
@@ -89,15 +89,15 @@ module.exports = {
     const halfWayRTT = rtt / 2;
     // Get the default network interface
     let iFace;
-    return this.stop().catch(() => {}).then(() => {
+    return this.stop().catch(() => {}).then(() =>
       getDefaultInterface()
         .then(iFace2 => {
           iFace = iFace2;
         })
         .then(() => modProbe())
         .then(() => setup(iFace))
-        .then(() => setLimits(up, down, halfWayRTT, iFace));
-    });
+        .then(() => setLimits(up, down, halfWayRTT, iFace))
+    );
   },
   stop() {
     return getDefaultInterface()


### PR DESCRIPTION
The promise that ran all tc setup commands was never actually returned, so we let the calling code proceed before setup had completed!