### PR TITLE
Don't require always passing `down`, `up` and `rtt` (fixes #19)

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -5,9 +5,6 @@
 const minimist = require('minimist');
 const throttler = require('../lib/');
 const packageInfo = require('../package');
-const defaultUp = 330;
-const defaultDown = 780;
-const defaultRtt = 200;
 
 const profiles = {
   '3g': {
@@ -87,11 +84,10 @@ if (argv.help || argv._[0] === 'help') {
       options = profiles[argv.profile || argv._[0]];
       console.log('Using profile ' + (argv.profile ? argv.profile : argv._[0]));
     } else {
-      console.log('Using default profile');
       options = {
-        up: argv.up || defaultUp,
-        down: argv.down || defaultDown,
-        rtt: argv.rtt || defaultRtt,
+        up: argv.up,
+        down: argv.down,
+        rtt: argv.rtt,
         localhost: argv.localhost
       };
     }
@@ -100,11 +96,19 @@ if (argv.help || argv._[0] === 'help') {
       if (options.localhost) {
         console.log(`Started throttler on localhost RTT:${options.rtt}ms `);
       } else {
-        console.log(
-          `Started throttler: Down:${options.down}kbit/s Up:${
-            options.up
-          }kbit/s RTT:${options.rtt}ms `
-        );
+        let msg = 'Started throttler:';
+
+        if (typeof options.down !== 'undefined') {
+          msg += ` Down:${options.down}kbit/s`;
+        }
+        if (typeof options.up !== 'undefined') {
+          msg += ` Up:${options.up}kbit/s`;
+        }
+        if (typeof options.rtt !== 'undefined') {
+          msg += ` RTT:${options.rtt}ms`;
+        }
+
+        console.log(msg);
       }
     });
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,9 +11,9 @@ function verify(options) {
       throw new Error('You need to set rtt as an integer for localhost');
     }
   } else if (
-    !Number.isInteger(options.up) ||
-    !Number.isInteger(options.down) ||
-    !Number.isInteger(options.rtt)
+    (typeof options.up !== 'undefined' && !Number.isInteger(options.up)) ||
+    (typeof options.down !== 'undefined' && !Number.isInteger(options.down)) ||
+    (typeof options.rtt !== 'undefined' && !Number.isInteger(options.rtt))
   ) {
     throw new Error('Input values needs to be integers');
   }

--- a/lib/pfctl.js
+++ b/lib/pfctl.js
@@ -7,6 +7,8 @@ const pfctlConfPath = path.resolve(confPath, 'pfctl.rules');
 
 module.exports = {
   async start(up, down, rtt) {
+    rtt = rtt || 0;
+
     const halfWayRTT = rtt / 2;
 
     await this.stop();
@@ -19,27 +21,30 @@ module.exports = {
     // Needs the right path
     await sudo('pfctl', '-f', pfctlConfPath);
 
-    await sudo(
-      'dnctl',
-      'pipe',
-      1,
-      'config',
-      'bw',
-      `${down}Kbit/s`,
-      'delay',
-      `${halfWayRTT}ms`
-    );
-
-    await sudo(
-      'dnctl',
-      'pipe',
-      2,
-      'config',
-      'bw',
-      `${up}Kbit/s`,
-      'delay',
-      `${halfWayRTT}ms`
-    );
+    if (typeof down !== 'undefined') {
+      await sudo(
+        'dnctl',
+        'pipe',
+        1,
+        'config',
+        'bw',
+        `${down}Kbit/s`,
+        'delay',
+        `${halfWayRTT}ms`
+      );
+    }
+    if (typeof up !== 'undefined') {
+      await sudo(
+        'dnctl',
+        'pipe',
+        2,
+        'config',
+        'bw',
+        `${up}Kbit/s`,
+        'delay',
+        `${halfWayRTT}ms`
+      );
+    }
     await sudo('pfctl', '-E');
   },
   async stop() {

--- a/lib/tc.js
+++ b/lib/tc.js
@@ -53,40 +53,46 @@ async function setup(defaultInterface) {
 }
 
 async function setLimits(up, down, halfWayRTT, iFace) {
-  await sudo(
-    'tc',
-    'qdisc',
-    'add',
-    'dev',
-    'ifb0',
-    'root',
-    'handle',
-    '1:0',
-    'netem',
-    'delay',
-    `${halfWayRTT}ms`,
-    'rate',
-    `${down}kbit`
-  );
-  await sudo(
-    'tc',
-    'qdisc',
-    'add',
-    'dev',
-    iFace,
-    'root',
-    'handle',
-    '1:0',
-    'netem',
-    'delay',
-    `${halfWayRTT}ms`,
-    'rate',
-    `${up}kbit`
-  );
+  if (typeof down !== 'undefined') {
+    await sudo(
+      'tc',
+      'qdisc',
+      'add',
+      'dev',
+      'ifb0',
+      'root',
+      'handle',
+      '1:0',
+      'netem',
+      'delay',
+      `${halfWayRTT}ms`,
+      'rate',
+      `${down}kbit`
+    );
+  }
+  if (typeof up !== 'undefined') {
+    await sudo(
+      'tc',
+      'qdisc',
+      'add',
+      'dev',
+      iFace,
+      'root',
+      'handle',
+      '1:0',
+      'netem',
+      'delay',
+      `${halfWayRTT}ms`,
+      'rate',
+      `${up}kbit`
+    );
+  }
 }
 
 module.exports = {
   async start(up, down, rtt) {
+    rtt = rtt || 0;
+
     const halfWayRTT = rtt / 2;
 
     try {


### PR DESCRIPTION
This PR makes it possible to set `down` without also having to limit `up` and `rtt` with default values. Specially useful if a user just want to limit downlink without also constraining uplink to an unknown default value.