### PR TITLE
Update the connectivity profiles to reflect those listed in WPT

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,15 @@ To make it easier we have pre made profiles, check them out by *throttle --help*
                      3g: up:768 down:1600 rtt:150
                      3gfast: up:768 down:1600 rtt:75
                      3gslow: up:400 down:400 rtt:200
-                     2g: up:32 down:35 rtt:650
+                     2g: up:256 down:280 rtt:400
                      cable: up:1000 down:5000 rtt:14
+                     dsl: up:384 down:1500 rtt:14
+                     3gem: up:400 down:400 rtt:200
+                     4g: up:9000 down:9000 rtt:85
+                     lte: up:12000 down:12000 rtt:35
+                     edge: up:200 down:240 rtt:35
+                     dial: up:30 down:49 rtt:60
+                     fois: up:5000 down:20000 rtt:2
 ```
 
 You can start throttle with one of the premade profiles:

--- a/bin/index.js
+++ b/bin/index.js
@@ -26,14 +26,49 @@ const profiles = {
     rtt: 200
   },
   '2g': {
-    down: 35,
-    up: 32,
-    rtt: 650
+    down: 280,
+    up: 256,
+    rtt: 400
   },
-  cable: {
+  'cable': {
     down: 5000,
     up: 1000,
     rtt: 14
+  },
+  'dsl': {
+    down: 1500,
+    up: 384,
+    rtt: 25
+  },
+  '3gem': {
+    down: 400,
+    up: 400,
+    rtt: 200
+  },
+  '4g': {
+    down: 9000,
+    up: 9000,
+    rtt: 85
+  },
+  'lte': {
+    down: 12000,
+    up: 12000,
+    rtt: 35
+  },
+  'edge': {
+    down: 240,
+    up: 200,
+    rtt: 420
+  },
+  'dial': {
+    down: 49,
+    up: 30,
+    rtt: 60
+  },
+  'fois': {
+    down: 20000,
+    up: 5000,
+    rtt: 2
   }
 };
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -26,9 +26,9 @@ const profiles = {
     rtt: 200
   },
   '2g': {
-    down: 280,
-    up: 256,
-    rtt: 400
+    down: 35,
+    up: 32,
+    rtt: 650
   },
   'cable': {
     down: 5000,

--- a/bin/index.js
+++ b/bin/index.js
@@ -30,12 +30,12 @@ const profiles = {
     up: 32,
     rtt: 650
   },
-  'cable': {
+  cable: {
     down: 5000,
     up: 1000,
     rtt: 14
   },
-  'dsl': {
+  dsl: {
     down: 1500,
     up: 384,
     rtt: 25
@@ -50,22 +50,22 @@ const profiles = {
     up: 9000,
     rtt: 85
   },
-  'lte': {
+  lte: {
     down: 12000,
     up: 12000,
     rtt: 35
   },
-  'edge': {
+  edge: {
     down: 240,
     up: 200,
     rtt: 420
   },
-  'dial': {
+  dial: {
     down: 49,
     up: 30,
     rtt: 60
   },
-  'fois': {
+  fois: {
     down: 20000,
     up: 5000,
     rtt: 2


### PR DESCRIPTION
Hey Peter,

Started using throttle today and was really missing the 4G profile for testing. So on adding it in I also decided to check the values and add in others as they are [listed in WebPageTest](https://github.com/WPO-Foundation/webpagetest/blob/26e3cf061c2395c949e125a155647db08eaf18b5/www/settings/connectivity.ini.sample). 

The `2G` profile in throttle is very slow compared to what is listed on WPT, so I'm unsure which one is correct? Looking at the [2G Wikipedia page](https://en.wikipedia.org/wiki/2G) throttle looks to be correct.