### PR TITLE
Throw error if tc interface retrieval fails

### DIFF
--- a/lib/tc.js
+++ b/lib/tc.js
@@ -7,11 +7,11 @@ async function getDefaultInterface() {
     "sudo route | grep '^default' | grep -o '[^ ]*$' | tr -d '\n'",
     { shell: true }
   );
-  
+
   if (result.stdout.length === 0 && result.stderr.length > 0) {
     throw new Error('There was an error getting the default interface:\n\n' + result.stderr);
   }
-  
+
   return result.stdout;
 }
 

--- a/lib/tc.js
+++ b/lib/tc.js
@@ -7,6 +7,11 @@ async function getDefaultInterface() {
     "sudo route | grep '^default' | grep -o '[^ ]*$' | tr -d '\n'",
     { shell: true }
   );
+  
+  if (result.stdout.length === 0 && result.stderr.length > 0) {
+    throw new Error('There was an error getting the default interface:\n\n' + result.stderr);
+  }
+  
   return result.stdout;
 }
 

--- a/lib/tc.js
+++ b/lib/tc.js
@@ -9,7 +9,9 @@ async function getDefaultInterface() {
   );
 
   if (result.stdout.length === 0 && result.stderr.length > 0) {
-    throw new Error('There was an error getting the default interface:\n\n' + result.stderr);
+    throw new Error(
+      'There was an error getting the default interface:\n\n' + result.stderr
+    );
   }
 
   return result.stdout;


### PR DESCRIPTION
On Linux if `net-tools` are not installed `tc` will fail to get the default interface using the `route` command. Or it might fail for any other reason.

This commit adds a safeguard to bug out on err and displays the actual stderr received instead of hiding it.

Closes: #55 