### PR TITLE
Fix breakage when multiple default routes are declared

### DIFF
--- a/lib/tc.js
+++ b/lib/tc.js
@@ -4,7 +4,7 @@ const sudo = require('./sudo');
 
 async function getDefaultInterface() {
   const result = await shell(
-    "sudo route | grep '^default' | grep -o '[^ ]*$' | tr -d '\n'",
+    "sudo route | grep -m 1 '^default' | grep -o '[^ ]*$' | tr -d '\n'",
     { shell: true }
   );
 


### PR DESCRIPTION
# About

Force parsing of single interface definition.

## The issue

I'm not sure if this is normal / invalid but I was getting the following error due to having multiple default destinations

```sh
> npx -p @sitespeed.io/throttle throttle 3gslow
Using profile 3gslow
Error: Command failed: sudo tc qdisc add dev wlp0s20f3wlp0s20f3 ingress
Cannot find device "wlp0s20f3wlp0s2"

    at ChildProcess.exithandler (node:child_process:326:12)
    at ChildProcess.emit (node:events:369:20)
    at maybeClose (node:internal/child_process:1067:16)
    at Process.ChildProcess._handle.onexit (node:internal/child_process:301:5) {
  killed: false,
  code: 1,
  signal: null,
  cmd: 'sudo tc qdisc add dev wlp0s20f3wlp0s20f3 ingress',
  stdout: '',
  stderr: 'Cannot find device "wlp0s20f3wlp0s2"\n'
}
```

```sh
> sudo route
Kernel IP routing table
Destination     Gateway         Genmask         Flags Metric Ref    Use Iface
default         OpenWrt.lan     0.0.0.0         UG    302    0        0 wlp0s20f3
default         OpenWrt.lan     0.0.0.0         UG    600    0        0 wlp0s20f3
172.17.0.0      0.0.0.0         255.255.0.0     U     0      0        0 docker0
172.18.0.0      0.0.0.0         255.255.0.0     U     0      0        0 br-672d84f52503
172.19.0.0      0.0.0.0         255.255.0.0     U     0      0        0 br-0f9d5dc90dec
192.168.1.0     0.0.0.0         255.255.255.0   U     302    0        0 wlp0s20f3
192.168.1.0     0.0.0.0         255.255.255.0   U     600    0        0 wlp0s20f3
192.168.48.0    0.0.0.0         255.255.240.0   U     0      0        0 br-bb989ac7cf64
192.168.122.0   0.0.0.0         255.255.255.0   U     0      0        0 virbr0
```
