### PR TITLE
feat: add dummynet ipv6 throttling commands

### DIFF
--- a/lib/pfctl.js
+++ b/lib/pfctl.js
@@ -14,9 +14,9 @@ export async function start(up, down, rtt = 0, packetLoss = 0) {
 
   await shell(
     'echo "dummynet in inet from any to ! 127.0.0.1 pipe 1\n' +
-    'dummynet out inet from ! 127.0.0.1 to any pipe 2\n' +
-    'dummynet in inet6 from any to ! ::1 pipe 1\n' +
-    'dummynet out inet6 from ! ::1 to any pipe 2" | sudo pfctl -f -'
+      'dummynet out inet from ! 127.0.0.1 to any pipe 2\n' +
+      'dummynet in inet6 from any to ! ::1 pipe 1\n' +
+      'dummynet out inet6 from ! ::1 to any pipe 2" | sudo pfctl -f -'
   );
 
   if (down) {

--- a/lib/pfctl.js
+++ b/lib/pfctl.js
@@ -13,7 +13,10 @@ export async function start(up, down, rtt = 0, packetLoss = 0) {
   await sudo('dnctl', 'pipe', 2, 'config', 'delay', '0ms', 'noerror');
 
   await shell(
-    'echo "dummynet in from any to ! 127.0.0.1 pipe 1\ndummynet out from ! 127.0.0.1 to any pipe 2" | sudo pfctl -f -'
+    'echo "dummynet in inet from any to ! 127.0.0.1 pipe 1\n' +
+    'dummynet out inet from ! 127.0.0.1 to any pipe 2\n' +
+    'dummynet in inet6 from any to ! ::1 pipe 1\n' +
+    'dummynet out inet6 from ! ::1 to any pipe 2" | sudo pfctl -f -'
   );
 
   if (down) {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

- The tool didn't work on my Mac Sequoia machine and after looking around the repo and online, I found that it happens to be an issue with ipv6. `dummynet` when used implicitly will only match `ipv4` (this needs to be confirmed). 

## Related Tickets & Documents

- https://github.com/sitespeedio/throttle/issues/87
- https://github.com/sitespeedio/throttle/issues/86
## Proposed Changes:
- Add ipv6 specific dummynet commands

# DISCLAIMER 
Modifications were done with the help of Deepseek Reasoning LLM model. Probably needing more reviews but after the changes, it works under my machine.